### PR TITLE
Issue #763 Exclude transitive config parser dep from testCompile

### DIFF
--- a/clustered/dist/build.gradle
+++ b/clustered/dist/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 
   serverLibs(project(':clustered:server')) {
     exclude group: 'org.terracotta', module: 'entity-server-api'
+    exclude group: 'org.terracotta', module: 'entity-common-api'
+    exclude group: 'org.terracotta', module: 'packaging-support'
+    exclude group: 'org.terracotta.internal', module: 'tc-config-parser'
   }
   serverLibs "org.terracotta:coordinator-entity-server:$parent.coordinatorVersion" changing true
 


### PR DESCRIPTION
So this is how exclusions are done in gradle... not sure if you want to merge it, or just steal from it... i didn't take the time to figure out if more exclusions would be required to strip all the 1.8 class files from the classpath.
